### PR TITLE
add logo width setting to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
 	"font": "Montserrat",
 	"siteId": "63bf0782ae27",
 	"logo_url": "https://us.coca-cola.com/content/dam/nagbrands/us/coke/en/coca-cola-logo.svg",
+	"logo_width": 96,
 	"img_bottom_left": "https://tomgsmith99-images.s3.amazonaws.com/forter/checking_accts.png",
 	"img_bottom_right": "https://tomgsmith99-images.s3.amazonaws.com/forter/hsa.png",
 

--- a/views/layouts/app.html
+++ b/views/layouts/app.html
@@ -179,8 +179,9 @@
                 {% block logo %}
                 <a href = "/">
                 <img
-                    class="w-24 mx-auto"
+                    class="mx-auto"
                     src="{{ logo_url }}"
+                    width="{{ logo_width }}"
                     alt=""
                 >
                 </a>


### PR DESCRIPTION
Previously the logo width had been set using a Tailwind utility class. It makes more sense to store this (in pixels) in `config.json`.