### PR TITLE
verification required partial

### DIFF
--- a/views/partials/decision-verify.html
+++ b/views/partials/decision-verify.html
@@ -1,0 +1,16 @@
+<div class="flex items-center gap-3 rounded border border-yellow-400 bg-yellow-100 p-3 text-yellow-900">
+    <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M8 0C3.5625 0 0 3.59375 0 8C0 12.4375 3.5625 16 8 16C12.4062 16 16 12.4375 16 8C16 3.59375 12.4062 0 8 0ZM8 4C8.53125 4 9 4.46875 9 5C9 5.5625 8.53125 6 8 6C7.4375 6 7 5.5625 7 5C7 4.46875 7.4375 4 8 4ZM9.25 12H6.75C6.3125 12 6 11.6875 6 11.25C6 10.8438 6.3125 10.5 6.75 10.5H7.25V8.5H7C6.5625 8.5 6.25 8.1875 6.25 7.75C6.25 7.34375 6.5625 7 7 7H8C8.40625 7 8.75 7.34375 8.75 7.75V10.5H9.25C9.65625 10.5 10 10.8438 10 11.25C10 11.6875 9.65625 12 9.25 12Z"
+            class="fill-yellow-500"
+        />
+    </svg>
+
+    <span>Forter decision: VERIFICATION REQUIRED</span>
+</div>


### PR DESCRIPTION
This adds a partial for a verification required alert style.

If you want to make the main box yellow like the design in Figma (screenshot below), then:

replace: `bg-gray-50 border border-gray-100`
with: `bg-yellow-50 border border-yellow-200`

![Screen Shot 2022-04-27 at 3 11 46 PM](https://user-images.githubusercontent.com/542720/165622940-11b529ab-1963-49be-90be-4053e52638e0.png)